### PR TITLE
Bugfix for whitespace error and prometheus components

### DIFF
--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -23,8 +23,9 @@ Red Hat Service Interconnect has been deployed successfully in your namespace.
 
 - {{ .Values.router.replicas }} of skupper-routers  
 - 1 replica of skupper-service-controller 
+{{ if .Values.flowCollector.enabled }}
 - 1 replica of skupper-prometheus pod
-
+{{- end }}
 Run the following commands to get more information on installation
 
 Status of installation.

--- a/templates/skupper-prometheus-cm.yaml
+++ b/templates/skupper-prometheus-cm.yaml
@@ -1,4 +1,5 @@
 {{ if not .Values.common.siteconfigonly }}
+{{ if .Values.flowCollector.enabled }}
 apiVersion: v1
 data:
   prometheus.yml: |2
@@ -37,3 +38,5 @@ kind: ConfigMap
 metadata:
   name: prometheus-server-config
 {{- end }}
+{{- end }}
+

--- a/templates/skupper-prometheus-role.yaml
+++ b/templates/skupper-prometheus-role.yaml
@@ -1,4 +1,5 @@
 {{ if not .Values.common.siteconfigonly }}
+{{ if .Values.flowCollector.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -62,4 +63,5 @@ rules:
   - get
   - list
   - watch
+{{- end }}
 {{- end }}

--- a/templates/skupper-prometheus-rolebinding.yaml
+++ b/templates/skupper-prometheus-rolebinding.yaml
@@ -1,4 +1,5 @@
 {{ if not .Values.common.siteconfigonly }}
+{{ if .Values.flowCollector.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -10,4 +11,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: skupper-prometheus
+{{- end }}
 {{- end }}

--- a/templates/skupper-prometheus-sa.yaml
+++ b/templates/skupper-prometheus-sa.yaml
@@ -1,7 +1,9 @@
 {{ if not .Values.common.siteconfigonly }}
+{{ if .Values.flowCollector.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: skupper-prometheus
 
+{{- end }}
 {{- end }}

--- a/templates/skupper-prometheus-svc.yaml
+++ b/templates/skupper-prometheus-svc.yaml
@@ -1,4 +1,5 @@
 {{ if not .Values.common.siteconfigonly }}
+{{ if .Values.flowCollector.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -16,4 +17,5 @@ spec:
     skupper.io/component: prometheus
   sessionAffinity: None
   type: ClusterIP
+{{- end }}
 {{- end }}

--- a/templates/skupper-prometheus.yaml
+++ b/templates/skupper-prometheus.yaml
@@ -1,4 +1,5 @@
 {{ if not .Values.common.siteconfigonly }}
+{{ if .Values.flowCollector.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -63,4 +64,5 @@ spec:
         name: prometheus-config
       - emptyDir: {}
         name: prometheus-storage-volume
+{{- end }}
 {{- end }}

--- a/templates/skupper-site-cm.yaml
+++ b/templates/skupper-site-cm.yaml
@@ -10,7 +10,7 @@ data:
   console-authentication: "{{ .Values.console.auth }}"
 {{- if .Values.common.customhostname }}
   ingress-host: "{{ .Values.common.ingress.domain }}"
-{{- end -}}
+{{- end }}
   ingress: "{{ .Values.common.ingressType }}"
   routers: "{{ .Values.router.replicas }}"
   router-mode: "{{ .Values.router.mode }}"


### PR DESCRIPTION
This PR fixes:
- a bug in templates/skupper-site-cm.yaml in whitespace, where a newline was chomped incorrectly
- a bug where prometheus components were created, even when flowCollector was not enabled