### PR TITLE
Cleaning up for one step install

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Run chart-testing (lint)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct lint --validate-maintainers false --target-branch ${{ github.event.repository.default_branch }}
+        run: ct lint --validate-maintainers false --check-version-increment false --target-branch ${{ github.event.repository.default_branch }} 
 
       - name: Create kind cluster
         if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -70,9 +70,9 @@ jobs:
           kubectl apply -f route-crd.yaml
           helm install --create-namespace --namespace skupper \
                skupper charts/rhsi
-          kubectl wait --for=condition=available --timeout=60s deploy/skupper-router
-          kubectl wait --for=condition=available --timeout=60s deploy/skupper-service-controller
-          kubectl wait --for=condition=available --timeout=60s deploy/skupper-prometheus
+          kubectl wait --for=condition=available --timeout=60s deploy/skupper-router -n skupper
+          kubectl wait --for=condition=available --timeout=60s deploy/skupper-service-controller -n skupper
+          kubectl wait --for=condition=available --timeout=60s deploy/skupper-prometheus -n skupper
           skupper debug events -n skupper | grep -q established
 
           

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -63,13 +63,33 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         uses: helm/kind-action@v1.7.0
 
-      - name: Install RHSI siteconfigOnly
+      - name: Install RHSI with Ingress Type Route
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           set -e
           kubectl apply -f route-crd.yaml
           helm install --create-namespace --namespace skupper \
                skupper charts/rhsi
+          kubectl wait --for=condition=available --timeout=60s deploy/skupper-router -n skupper
+          kubectl wait --for=condition=available --timeout=60s deploy/skupper-service-controller -n skupper
+          kubectl wait --for=condition=available --timeout=60s deploy/skupper-prometheus -n skupper
+          skupper debug events -n skupper | grep -q established
+
+      - name: Install RHSI with Ingress Type LoadBalancer
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+          set -e
+          helm upgrade --install skupper ./ -n skupper-3 --create-namespace --set common.ingressType=loadbalancer
+          kubectl wait --for=condition=available --timeout=60s deploy/skupper-router -n skupper
+          kubectl wait --for=condition=available --timeout=60s deploy/skupper-service-controller -n skupper
+          kubectl wait --for=condition=available --timeout=60s deploy/skupper-prometheus -n skupper
+          skupper debug events -n skupper | grep -q established
+
+      - name: Install RHSI with Ingress Type nodeport
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+          set -e
+          helm upgrade --install skupper ./ -n skupper-3 --create-namespace --set common.ingressType=nodeport
           kubectl wait --for=condition=available --timeout=60s deploy/skupper-router -n skupper
           kubectl wait --for=condition=available --timeout=60s deploy/skupper-service-controller -n skupper
           kubectl wait --for=condition=available --timeout=60s deploy/skupper-prometheus -n skupper

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -67,6 +67,7 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           set -e
+          kubectl apply -f route-crd.yaml
           helm install --create-namespace --namespace skupper \
                skupper charts/rhsi
           kubectl wait --for=condition=available --timeout=60s deploy/skupper-router

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -79,7 +79,7 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           set -e
-          helm upgrade --install skupper ./ -n skupper-3 --create-namespace --set common.ingressType=loadbalancer
+          helm upgrade --install skupper charts/rhsi -n skupper-2 --create-namespace --set common.ingressType=loadbalancer
           kubectl wait --for=condition=available --timeout=60s deploy/skupper-router -n skupper
           kubectl wait --for=condition=available --timeout=60s deploy/skupper-service-controller -n skupper
           kubectl wait --for=condition=available --timeout=60s deploy/skupper-prometheus -n skupper
@@ -89,7 +89,7 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           set -e
-          helm upgrade --install skupper ./ -n skupper-3 --create-namespace --set common.ingressType=nodeport
+          helm upgrade --install skupper charts/rhsi -n skupper-3 --create-namespace --set common.ingressType=nodeport
           kubectl wait --for=condition=available --timeout=60s deploy/skupper-router -n skupper
           kubectl wait --for=condition=available --timeout=60s deploy/skupper-service-controller -n skupper
           kubectl wait --for=condition=available --timeout=60s deploy/skupper-prometheus -n skupper

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -20,18 +20,23 @@ jobs:
         with:
           version: v3.12.1
 
-      - name: Set up podman
-        run: |
-          source /etc/os-release
-          echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
-          curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
-          sudo apt-get update
-          sudo apt-get -y install podman
+      # - name: Set up podman
+      #   run: |
+      #     source /etc/os-release
+      #     echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+      #     curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
+      #     sudo apt-get update
+      #     sudo apt-get -y install podman
 
       - name: Set up oc client
         run: |
           wget https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz
           sudo tar xzvf oc.tar.gz -C /usr/local/bin
+
+      - name: Install skupper cli
+        run: |
+          curl https://skupper.io/install.sh | sh
+          skupper version
           
       - uses: actions/setup-python@v4
         with:
@@ -61,8 +66,14 @@ jobs:
       - name: Install RHSI siteconfigOnly
         if: steps.list-changed.outputs.changed == 'true'
         run: |
+          set -e
           helm install --create-namespace --namespace skupper \
-               skupper charts/rhsi --set common.siteconfigonly=true
-          helm template charts/rhsi --set common.siteconfigonly=false
+               skupper charts/rhsi
+          kubectl wait --for=condition=available --timeout=60s deploy/skupper-router
+          kubectl wait --for=condition=available --timeout=60s deploy/skupper-service-controller
+          kubectl wait --for=condition=available --timeout=60s deploy/skupper-prometheus
+          skupper debug events -n skupper | grep -q established
+
+          
 
             

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,10 @@ jobs:
         with:
           version: v3.8.1
 
+      - name: Run chart-testing (lint)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct lint --validate-maintainers false --target-branch ${{ github.event.repository.default_branch }} 
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0
         with:

--- a/charts/rhsi/Chart.yaml
+++ b/charts/rhsi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: skupper
 description: A Helm chart for Red Hat Service interconnect installation
 type: application
-version: 1.5.4
+version: 1.5.5
 appVersion: "1.4.2"
 maintainers:
   - email: rmallam@redhat.com

--- a/charts/rhsi/templates/NOTES.txt
+++ b/charts/rhsi/templates/NOTES.txt
@@ -3,19 +3,7 @@
 ***               RED HAT Service Interconnect                 ***
 *******************************************************************
 
-{{- if .Values.common.siteconfigonly }}
 
-you have deployed only skupper-site configmap.
-
-Run the following to see the resource
-
- oc get cm skupper-site -o yaml 
-
-you will now have to run the following to deploy the other components of RHSI.
-
-helm upgrade --install skupper ./ --set common.siteconfigonly=false 
-
-{{- end -}}
 
 {{- if not .Values.common.siteconfigonly }}
 
@@ -48,7 +36,7 @@ Skupper cli can be downloaded here chttps://skupper.io/releases/index.html
 
 {{- end -}}
 
-{{- if and .Values.linkTokenCreate .Values.selfSignedCerts -}}
+{{- if and .Values.linkTokenCreate .Values.selfSignedCerts }}
 
         ***** Link information *****
 

--- a/charts/rhsi/templates/claims-route.yaml
+++ b/charts/rhsi/templates/claims-route.yaml
@@ -1,4 +1,4 @@
-{{ if and (not .Values.common.siteconfigonly) (eq .Values.common.ingressType "route") }}
+{{ if eq .Values.common.ingressType "route" }}
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:

--- a/charts/rhsi/templates/secrets.yaml
+++ b/charts/rhsi/templates/secrets.yaml
@@ -1,4 +1,4 @@
-{{ if not .Values.common.siteconfigonly }}
+
 {{ $certs := ( include "selfsignedcerts" $ ) | fromYaml }}
 {{ $staticTokenData := ( include "token.metadata" $ ) }}
 {{- range .Values.secrets }}
@@ -26,8 +26,8 @@ data:
 {{- else -}}
 {{ (tpl ($.Files.Glob "certs/*").AsSecrets $ ) | nindent 4 }}
 {{- end -}}
-{{- end -}}
 {{- end }}
+
 # Secrets for remote sites, when using custom certificates
 {{ if and $.Values.linkTokenCreate (not .Values.selfSignedCerts) }}
 {{ $staticTokenData := ( include "token.metadata" $ ) }}

--- a/charts/rhsi/templates/skupper-connectjson-cm.yaml
+++ b/charts/rhsi/templates/skupper-connectjson-cm.yaml
@@ -1,4 +1,4 @@
-{{ if not .Values.common.siteconfigonly }}
+
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -16,4 +16,3 @@ data:
         "verify": true
         }
     } 
-{{- end }}

--- a/charts/rhsi/templates/skupper-console-users-secret.yaml
+++ b/charts/rhsi/templates/skupper-console-users-secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.common.siteconfigonly }}
+
 {{- if and .Values.console.enabled (eq (.Values.console.auth) "internal") }}
 {{ $consolesecret := ( include "consolesecret" $ ) }}
 kind: Secret
@@ -8,5 +8,4 @@ metadata:
 data:
 {{ $consolesecret | indent 2 }}
 type: Opaque
-{{- end -}}
 {{- end -}}

--- a/charts/rhsi/templates/skupper-console-users-sercret.yaml
+++ b/charts/rhsi/templates/skupper-console-users-sercret.yaml
@@ -1,4 +1,4 @@
-{{ if not .Values.siteconfigonly }}
+
 apiVersion: v1
 data:
   admin: YURtSU5AMQo=
@@ -6,4 +6,3 @@ kind: Secret
 metadata:
   name: skupper-console-users
 type: Opaque
-{{- end }}

--- a/charts/rhsi/templates/skupper-internal-cm.yaml
+++ b/charts/rhsi/templates/skupper-internal-cm.yaml
@@ -1,4 +1,3 @@
-{{ if not .Values.common.siteconfigonly }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -111,4 +110,3 @@ data:
             }
         ]
     ]
-{{- end }}

--- a/charts/rhsi/templates/skupper-metrics-route.yaml
+++ b/charts/rhsi/templates/skupper-metrics-route.yaml
@@ -1,4 +1,4 @@
-{{ if and (not .Values.common.siteconfigonly) (eq .Values.common.ingressType "route") }}
+{{ if  eq .Values.common.ingressType "route" }}
 kind: Route
 apiVersion: route.openshift.io/v1
 metadata:

--- a/charts/rhsi/templates/skupper-prometheus-cm.yaml
+++ b/charts/rhsi/templates/skupper-prometheus-cm.yaml
@@ -1,4 +1,4 @@
-{{ if not .Values.common.siteconfigonly }}
+
 {{ if .Values.flowCollector.enabled }}
 apiVersion: v1
 data:
@@ -38,5 +38,5 @@ kind: ConfigMap
 metadata:
   name: prometheus-server-config
 {{- end }}
-{{- end }}
+
 

--- a/charts/rhsi/templates/skupper-prometheus-role.yaml
+++ b/charts/rhsi/templates/skupper-prometheus-role.yaml
@@ -1,4 +1,4 @@
-{{ if not .Values.common.siteconfigonly }}
+
 {{ if .Values.flowCollector.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -63,5 +63,4 @@ rules:
   - get
   - list
   - watch
-{{- end }}
 {{- end }}

--- a/charts/rhsi/templates/skupper-prometheus-rolebinding.yaml
+++ b/charts/rhsi/templates/skupper-prometheus-rolebinding.yaml
@@ -1,4 +1,4 @@
-{{ if not .Values.common.siteconfigonly }}
+
 {{ if .Values.flowCollector.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -11,5 +11,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: skupper-prometheus
-{{- end }}
 {{- end }}

--- a/charts/rhsi/templates/skupper-prometheus-sa.yaml
+++ b/charts/rhsi/templates/skupper-prometheus-sa.yaml
@@ -1,4 +1,4 @@
-{{ if not .Values.common.siteconfigonly }}
+
 {{ if .Values.flowCollector.enabled }}
 apiVersion: v1
 kind: ServiceAccount
@@ -6,4 +6,4 @@ metadata:
   name: skupper-prometheus
 
 {{- end }}
-{{- end }}
+

--- a/charts/rhsi/templates/skupper-prometheus-svc.yaml
+++ b/charts/rhsi/templates/skupper-prometheus-svc.yaml
@@ -1,4 +1,4 @@
-{{ if not .Values.common.siteconfigonly }}
+
 {{ if .Values.flowCollector.enabled }}
 apiVersion: v1
 kind: Service
@@ -18,4 +18,4 @@ spec:
   sessionAffinity: None
   type: ClusterIP
 {{- end }}
-{{- end }}
+

--- a/charts/rhsi/templates/skupper-prometheus.yaml
+++ b/charts/rhsi/templates/skupper-prometheus.yaml
@@ -1,4 +1,4 @@
-{{ if not .Values.common.siteconfigonly }}
+
 {{ if .Values.flowCollector.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -60,4 +60,4 @@ spec:
       - emptyDir: {}
         name: prometheus-storage-volume
 {{- end }}
-{{- end }}
+

--- a/charts/rhsi/templates/skupper-router-deployment.yaml
+++ b/charts/rhsi/templates/skupper-router-deployment.yaml
@@ -1,4 +1,4 @@
-{{ if not .Values.common.siteconfigonly }}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -170,4 +170,3 @@ spec:
           defaultMode: 420
       - name: sharedvol
         emptyDir: {}
-{{- end }}

--- a/charts/rhsi/templates/skupper-router-local-svc.yaml
+++ b/charts/rhsi/templates/skupper-router-local-svc.yaml
@@ -1,4 +1,4 @@
-{{ if not .Values.common.siteconfigonly }}
+
 kind: Service
 apiVersion: v1
 metadata:
@@ -15,4 +15,3 @@ spec:
     application: skupper-router
     skupper.io/component: router
   type: ClusterIP
-{{- end }}

--- a/charts/rhsi/templates/skupper-router-role.yaml
+++ b/charts/rhsi/templates/skupper-router-role.yaml
@@ -1,4 +1,4 @@
-{{ if not .Values.common.siteconfigonly }}
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -14,4 +14,3 @@ rules:
   - get
   - list
   - watch
-{{- end }}

--- a/charts/rhsi/templates/skupper-router-rolebinding.yaml
+++ b/charts/rhsi/templates/skupper-router-rolebinding.yaml
@@ -1,4 +1,4 @@
-{{ if not .Values.common.siteconfigonly }}
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -10,4 +10,3 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: skupper-router
-{{- end }}

--- a/charts/rhsi/templates/skupper-router-route.yaml
+++ b/charts/rhsi/templates/skupper-router-route.yaml
@@ -1,4 +1,4 @@
-{{ if and (not .Values.common.siteconfigonly) (eq .Values.common.ingressType "route") }}
+{{ if eq .Values.common.ingressType "route" }}
 ---
 apiVersion: route.openshift.io/v1
 kind: Route

--- a/charts/rhsi/templates/skupper-router-sa.yaml
+++ b/charts/rhsi/templates/skupper-router-sa.yaml
@@ -1,6 +1,5 @@
-{{ if not .Values.common.siteconfigonly }}
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: skupper-router
-{{- end }}

--- a/charts/rhsi/templates/skupper-router-svc.yaml
+++ b/charts/rhsi/templates/skupper-router-svc.yaml
@@ -1,4 +1,4 @@
-{{ if not .Values.common.siteconfigonly }}
+
 kind: Service
 apiVersion: v1
 metadata:
@@ -19,4 +19,3 @@ spec:
     application: skupper-router
     skupper.io/component: router
   type: {{ include "router.svctype" .}}
-{{- end }}

--- a/charts/rhsi/templates/skupper-service-controller-deploy.yaml
+++ b/charts/rhsi/templates/skupper-service-controller-deploy.yaml
@@ -67,6 +67,8 @@ spec:
         image: {{ .Values.serviceController.image.repository }}:{{ .Values.serviceController.image.version }}
         command: ["/bin/sh", "-c", "source /etc/sharedvol/env && /app/service-controller"]
         imagePullPolicy: Always
+        securityContext:
+          runAsNonRoot: true
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -107,6 +109,7 @@ spec:
             memory: "{{ .Values.serviceController.memory.requests }}"
         securityContext:
           runAsNonRoot: true
+          runAsUser: 2000
         startupProbe:
           failureThreshold: 60
           httpGet:
@@ -163,6 +166,7 @@ spec:
               memory: "{{ .Values.flowCollector.memory.requests }}"
         securityContext:
           runAsNonRoot: true
+          runAsUser: 2000
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -194,6 +198,7 @@ spec:
       schedulerName: default-scheduler
       securityContext:
         runAsNonRoot: true
+        runAsUser: 2000
       serviceAccount: skupper-service-controller
       serviceAccountName: skupper-service-controller
       terminationGracePeriodSeconds: 30

--- a/charts/rhsi/templates/skupper-service-controller-deploy.yaml
+++ b/charts/rhsi/templates/skupper-service-controller-deploy.yaml
@@ -67,8 +67,6 @@ spec:
         image: {{ .Values.serviceController.image.repository }}:{{ .Values.serviceController.image.version }}
         command: ["/bin/sh", "-c", "source /etc/sharedvol/env && /app/service-controller"]
         imagePullPolicy: Always
-        securityContext:
-          runAsNonRoot: true
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -168,7 +166,9 @@ spec:
               memory: "{{ .Values.flowCollector.memory.requests }}"
         securityContext:
           runAsNonRoot: true
+{{- if not (eq (.Values.common.cluster) "openshift") }}
           runAsUser: 2000
+{{- end }}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/charts/rhsi/templates/skupper-service-controller-deploy.yaml
+++ b/charts/rhsi/templates/skupper-service-controller-deploy.yaml
@@ -109,7 +109,9 @@ spec:
             memory: "{{ .Values.serviceController.memory.requests }}"
         securityContext:
           runAsNonRoot: true
-          runAsUser: 2000
+{{- if not (eq (.Values.common.cluster) "openshift") }}
+        runAsUser: 2000
+{{- end }}
         startupProbe:
           failureThreshold: 60
           httpGet:
@@ -198,7 +200,9 @@ spec:
       schedulerName: default-scheduler
       securityContext:
         runAsNonRoot: true
+{{- if not (eq (.Values.common.cluster) "openshift") }}
         runAsUser: 2000
+{{- end }}
       serviceAccount: skupper-service-controller
       serviceAccountName: skupper-service-controller
       terminationGracePeriodSeconds: 30

--- a/charts/rhsi/templates/skupper-service-controller-role.yaml
+++ b/charts/rhsi/templates/skupper-service-controller-role.yaml
@@ -1,5 +1,5 @@
 
-{{ if not .Values.common.siteconfigonly }}
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -67,4 +67,3 @@ rules:
   - get
   - list
   - watch
-{{- end }}

--- a/charts/rhsi/templates/skupper-service-controller-rolebinding.yaml
+++ b/charts/rhsi/templates/skupper-service-controller-rolebinding.yaml
@@ -1,4 +1,4 @@
-{{ if not .Values.common.siteconfigonly }}
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -10,4 +10,3 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: skupper-service-controller
-{{- end }}

--- a/charts/rhsi/templates/skupper-service-controller-sa.yaml
+++ b/charts/rhsi/templates/skupper-service-controller-sa.yaml
@@ -1,6 +1,5 @@
-{{ if not .Values.common.siteconfigonly }}
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: skupper-service-controller
-{{- end }}

--- a/charts/rhsi/templates/skupper-services-cm.yaml
+++ b/charts/rhsi/templates/skupper-services-cm.yaml
@@ -1,7 +1,6 @@
-{{ if not .Values.common.siteconfigonly }}
+
 apiVersion: v1
 data:
 kind: ConfigMap
 metadata:
   name: skupper-services
-{{- end }}

--- a/charts/rhsi/templates/skupper-svc.yaml
+++ b/charts/rhsi/templates/skupper-svc.yaml
@@ -1,4 +1,4 @@
-{{ if not .Values.common.siteconfigonly }}
+
 apiVersion: v1
 kind: Service
 metadata:
@@ -23,4 +23,3 @@ spec:
     skupper.io/component: service-controller
   sessionAffinity: None
   type: {{ include "router.svctype" .}}
-{{- end }}

--- a/charts/rhsi/values.yaml
+++ b/charts/rhsi/values.yaml
@@ -3,6 +3,7 @@
 # image versions are based on the releases from skupper.io, Every release of skupper will have four containers(at the time of document 20/10). Check the mainfest for each release and push them to DTR.
 common:
   siteconfigonly: false
+  cluster: other # [openshift|other - mainly used for runasuser config]
   ingressType: "route"  #  [route|loadbalancer|nodeport|nginx-ingress-v1|contour-http-proxy|ingress|none]. If not specified route is used when available, otherwise loadbalancer is used.
   ingress:
     domain: "apps.example.com"  #  Domain of the cluster, like "apps-int.di1001.cpaas.test". mainly used for routes

--- a/charts/rhsi/values.yaml
+++ b/charts/rhsi/values.yaml
@@ -3,7 +3,7 @@
 # image versions are based on the releases from skupper.io, Every release of skupper will have four containers(at the time of document 20/10). Check the mainfest for each release and push them to DTR.
 common:
   siteconfigonly: false
-  cluster: other #  [openshift|other - mainly used for runasuser config]
+  cluster: other  #  [openshift|other - mainly used for runasuser config]
   ingressType: "route"  #  [route|loadbalancer|nodeport|nginx-ingress-v1|contour-http-proxy|ingress|none]. If not specified route is used when available, otherwise loadbalancer is used.
   ingress:
     domain: "apps.example.com"  #  Domain of the cluster, like "apps-int.di1001.cpaas.test". mainly used for routes

--- a/charts/rhsi/values.yaml
+++ b/charts/rhsi/values.yaml
@@ -3,7 +3,7 @@
 # image versions are based on the releases from skupper.io, Every release of skupper will have four containers(at the time of document 20/10). Check the mainfest for each release and push them to DTR.
 common:
   siteconfigonly: false
-  cluster: other # [openshift|other - mainly used for runasuser config]
+  cluster: other #  [openshift|other - mainly used for runasuser config]
   ingressType: "route"  #  [route|loadbalancer|nodeport|nginx-ingress-v1|contour-http-proxy|ingress|none]. If not specified route is used when available, otherwise loadbalancer is used.
   ingress:
     domain: "apps.example.com"  #  Domain of the cluster, like "apps-int.di1001.cpaas.test". mainly used for routes

--- a/route-crd.yaml
+++ b/route-crd.yaml
@@ -1,0 +1,44 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: routes.route.openshift.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: route.openshift.io
+  # list of versions supported by this CustomResourceDefinition
+  versions:
+    - name: v1
+      # Each version can be enabled/disabled by Served flag.
+      served: true
+      # One and only one version must be marked as the storage version.
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      additionalPrinterColumns:
+        - name: Host
+          type: string
+          jsonPath: .status.ingress[0].host
+        - name: Admitted
+          type: string
+          jsonPath: .status.ingress[0].conditions[?(@.type=="Admitted")].status
+        - name: Service
+          type: string
+          jsonPath: .spec.to.name
+        - name: TLS
+          type: string
+          jsonPath: .spec.tls.type
+      subresources:
+        # enable spec/status
+        status: {}
+  # either Namespaced or Cluster
+  scope: Namespaced
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: routes
+    # singular name to be used as an alias on the CLI and for display
+    singular: route
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: Route


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ Y ] is the chart version updated in chart.yaml file ( for bug fixes / features )
- [  Y ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Cleaning up for one step install,
Removed the check for site config map install from components and added a new workflow test

* **What is the current behavior?** (You can also link to an open issue here)
Currently the helm chart checks if the install is only for site configmap or a full installl, Removed the check by introducing the  init container.

* **What is the new behavior (if this is a feature change)?**
One step installation of skupper

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
None

* **Other information**:

